### PR TITLE
fix: throwing an error when modules are imported in the wrong order

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ _preventDefault()_ and _stopPropagation()_.
     export class AppModule {}
     ```
 
-> `BrowserModule` or `BrowserAnimationsModule` must go first. You will see a warning if you mess the order.
+> `BrowserModule` or `BrowserAnimationsModule` must go first. You will see an error thrown if you mess the order.
 
 2. Use new modifiers for events in templates and in `@HostListener`:
 

--- a/projects/ng-event-plugins/src/module.ts
+++ b/projects/ng-event-plugins/src/module.ts
@@ -9,9 +9,10 @@ import {SilentEventPlugin} from './plugins/silent.plugin';
 })
 export class EventPluginsModule {
     constructor(@Inject(EVENT_MANAGER_PLUGINS) plugins: readonly unknown[]) {
-        console.assert(
-            !(plugins[0] instanceof SilentEventPlugin),
-            'EventManagerModule must come after BrowserModule in imports',
-        );
+        if (plugins[0] instanceof SilentEventPlugin) {
+            throw new Error(
+                'EventManagerModule must come after BrowserModule or BrowserAnimationsModule in imports',
+            );
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

If module orders is wrong, an assertion will show an error in console.

Issue Number: N/A

## What is the new behavior?

Instead of using `console.assert`, an error will be thrown.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
